### PR TITLE
Change to version 3.25

### DIFF
--- a/services/syslog-ng/syslog-ng.conf
+++ b/services/syslog-ng/syslog-ng.conf
@@ -1,4 +1,4 @@
-@version: 3.5
+@version: 3.25
 @include "scl.conf"
 
 # Syslog-ng configuration file, compatible with default Debian syslogd


### PR DESCRIPTION
This stops warnings during running of the form 

> WARNING: Configuration file format is too old, syslog-ng is running in compatibility mode. Please update it to use the syslog-ng 3.25 format at your time of convenience. To upgrade the configuration, please review the warnings about incompatible changes printed by syslog-ng, and once completed change the @version header at the top of the configuration file; config-version='3.5'

The only issues flagged during startup are:

>  WARNING: log-fifo-size() works differently starting with syslog-ng 3.22 to avoid dropping flow-controlled messages when log-fifo-size() is misconfigured. From now on, log-fifo-size() only affects messages that are not flow-controlled. (Flow-controlled log paths have the flags(flow-control) option set.) To enable the new behaviour, update the @version string in your configuration and consider lowering the value of log-fifo-size().;

And `log-fifo-size` is not used in this syslog-ng setup anyway